### PR TITLE
Add i2c function to read i2c device register

### DIFF
--- a/Lib/LibNativeI2C/src/libNativeI2C.c
+++ b/Lib/LibNativeI2C/src/libNativeI2C.c
@@ -39,3 +39,35 @@ int readBytes (int busHandle, int addr, byte* buf, int len)
 
 	return n;
 }
+
+
+int readRegister(int busHandle, int address, unsigned char reg, unsigned char *data) 
+{
+    unsigned char input_buffer, output_buffer;
+    struct i2c_rdwr_ioctl_data packets;
+    struct i2c_msg messages[2];
+
+    output_buffer = reg;
+    messages[0].addr  = address;
+    messages[0].flags = 0;
+    messages[0].len   = sizeof(output_buffer);
+    messages[0].buf   = &output_buffer;
+
+    messages[1].addr  = address;
+    messages[1].flags = I2C_M_RD;
+    messages[1].len   = sizeof(input_buffer);
+    messages[1].buf   = &input_buffer;
+
+    packets.msgs      = messages;
+    packets.nmsgs     = 2;
+
+    if(ioctl(busHandle, I2C_RDWR, &packets) < 0) {
+        perror("Error sending data");
+        return 1;
+    }
+    *data = input_buffer;
+
+    return 0;
+}
+
+

--- a/Lib/LibNativeI2C/src/libNativeI2C.c
+++ b/Lib/LibNativeI2C/src/libNativeI2C.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <linux/i2c.h>
 #include <linux/i2c-dev.h>
 #include <fcntl.h>
 #include <string.h>
@@ -69,5 +70,4 @@ int readRegister(int busHandle, int address, unsigned char reg, unsigned char *d
 
     return 0;
 }
-
 

--- a/Lib/LibNativeI2C/src/libNativeI2C.h
+++ b/Lib/LibNativeI2C/src/libNativeI2C.h
@@ -11,7 +11,7 @@ extern int openBus (char*);
 extern int closeBus (int);
 extern int writeBytes (int, int, byte*, int);
 extern int readBytes (int, int, byte*, int);
-
+extern int readRegister(int, int, unsigned char, unsigned char*); 
 
 #ifdef __cplusplus
 }

--- a/RPi.I2C.Net/I2CBus.cs
+++ b/RPi.I2C.Net/I2CBus.cs
@@ -166,5 +166,14 @@ namespace RPi.I2C.Net
 
 			return buf;
 		}
+
+
+        public byte[] ReadDeviceRegister(int address, byte register)
+        {
+            byte[] buf = new byte[10];
+            int res = I2CNativeLib.readRegister(busHandle, address, register ,buf);
+            return (buf);
+        
+        }
 	}
 }

--- a/RPi.I2C.Net/I2CNativeLib.cs
+++ b/RPi.I2C.Net/I2CNativeLib.cs
@@ -15,5 +15,8 @@ namespace RPi.I2C.Net
 
 		[DllImport("libnativei2c.so", EntryPoint = "writeBytes", SetLastError = true)]
 		public static extern int WriteBytes(int busHandle, int addr, byte[] buf, int len);
+
+        [DllImport("libnativei2c.so", EntryPoint = "readRegister", SetLastError = true)]
+        public static extern int readRegister(int busHandle, int address, byte register, byte[] data);
 	}
 }

--- a/RPi.I2C.Net/II2CBus.cs
+++ b/RPi.I2C.Net/II2CBus.cs
@@ -54,5 +54,14 @@ namespace RPi.I2C.Net
 		/// <returns></returns>
 		byte[] ReadBytes(int address, int count);
 
+        /// <summary>
+        /// Read a byte from device register
+        /// </summary>
+        /// <param name="address">: device address on i2c bus</param>
+        /// <param name="register : address of a register"></param>
+        /// <returns></returns>
+
+        byte[] ReadDeviceRegister(int address, byte register);
+
 	}
 }

--- a/RPi.I2C.Net/RPi.I2C.Net.csproj
+++ b/RPi.I2C.Net/RPi.I2C.Net.csproj
@@ -11,7 +11,8 @@
     <AssemblyName>RPi.I2C.Net</AssemblyName>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile>Mono</TargetFrameworkProfile>
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -31,7 +32,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Mono.Posix" />
+    <Reference Include="Mono.Posix">
+      <HintPath>C:\Program Files (x86)\Mono-2.10.9\lib\mono\4.0\Mono.Posix.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
   </ItemGroup>


### PR DESCRIPTION
Hello

thank you very much for your C# i2c library. It works out of the box and I am using it. I enjoy running .NET assemblies created with VS Studio on my Windows host and finally excute them on Raspberry via Mono.

About this pull request:

Some i2c devices are internally organised by a set of Registers. Therefore I have added and tested the function readRegister().
The function requires the i2c bus device address and the Register address. It Returns the Content of the Register.

It may be useful for other users too.

It is used in Rpi.LCD_Display.NET to read the inputs attached to the MPC23017 port expander

best regards
Carsten 
